### PR TITLE
Added root file for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+  - oraclejdk6
+  - openjdk6


### PR DESCRIPTION
This configuration file enables Travis-CI.org support on this project.

By default it tries to build Jadler by both OracleJDK6 and OpenJDK6.
