### PR TITLE
StubRule renamed to HttpStub. JadlerMocker has now a close() method instead of stop()

### DIFF
--- a/jadler-core/src/main/java/net/jadler/Jadler.java
+++ b/jadler-core/src/main/java/net/jadler/Jadler.java
@@ -498,7 +498,7 @@ public class Jadler {
     public static void closeJadler() {
         final StubHttpServerManager serverManager = jadlerMockerContainer.get();
         if (serverManager != null && serverManager.isStarted()) {
-            serverManager.stop();
+            serverManager.close();
         }
         
         jadlerMockerContainer.set(null);

--- a/jadler-core/src/main/java/net/jadler/stubbing/HttpStub.java
+++ b/jadler-core/src/main/java/net/jadler/stubbing/HttpStub.java
@@ -19,10 +19,9 @@ import static org.hamcrest.Matchers.*;
 
 
 /**
- * TODO: shouldn't this be called HttpStub instead of StubRule?
- * A stub rule is a <i>WHEN</i>-<i>THEN</i> pair (when a http request with specific properties arrives, then respond
- * with a defined http response).
- * The <i>WHEN<i> part is a list of predicates (in form of Hamcrest matchers) applied to a request. All of these
+ * An http stub is a <i>WHEN</i>-<i>THEN</i> pair (when an http request with specific properties arrives, then respond
+ * with a defined response).
+ * The <i>WHEN<i> part is a list of predicates (in form of Hamcrest matchers) applicable to a request. All of these
  * matchers must be evaluated to <tt>true</tt> in order to apply the <i>THEN</i> part.
  * 
  * The <i>THEN</i> part if defined by a non-empty list of stub response definition (in form of {@link StubResponse}
@@ -33,7 +32,7 @@ import static org.hamcrest.Matchers.*;
  * 
  * One should never create new instances of this class directly, see {@link net.jadler.Jadler} for explanation and tutorial.
  */
-public class StubRule {
+public class HttpStub {
 
     private final Collection<Matcher<? super Request>> predicates;
     private final List<StubResponse> stubResponses;
@@ -45,7 +44,7 @@ public class StubRule {
      * be matched by every request)
      * @param stubResponses list of stub response definitions. Must contain at least one stub response.
      */
-    public StubRule(final Collection<Matcher<? super Request>> predicates,
+    public HttpStub(final Collection<Matcher<? super Request>> predicates,
             final List<StubResponse> stubResponses) {
         Validate.notNull(predicates, "predicates cannot be null, use an empty list instead");
         this.predicates = new ArrayList<Matcher<? super Request>>(predicates);
@@ -60,7 +59,7 @@ public class StubRule {
      * @return true if and only if all predicates defined in this rule were evaluated to {@code true}
      * by the given request.
      */
-    public boolean matchedBy(final Request request) {
+    public boolean matches(final Request request) {
         return allOf(this.predicates).matches(request);
     }
 

--- a/jadler-core/src/main/java/net/jadler/stubbing/Stubbing.java
+++ b/jadler-core/src/main/java/net/jadler/stubbing/Stubbing.java
@@ -194,12 +194,12 @@ public class Stubbing extends AbstractRequestMatching<RequestStubbing> implement
     
     
     /**
-     * Creates a {@link StubRule} instance from this Stubbing instance.
+     * Creates a {@link HttpStub} instance from this Stubbing instance.
      * Must be called once this stubbing has been finished.
-     * @return {@link StubRule} instance configured using values from this stubbing
+     * @return {@link HttpStub} instance configured using values from this stubbing
      */
-    public StubRule createRule() {
-        return new StubRule(predicates, stubResponses);
+    public HttpStub createRule() {
+        return new HttpStub(predicates, stubResponses);
     }
     
     

--- a/jadler-core/src/main/java/net/jadler/stubbing/server/StubHttpServerManager.java
+++ b/jadler-core/src/main/java/net/jadler/stubbing/server/StubHttpServerManager.java
@@ -7,7 +7,6 @@ package net.jadler.stubbing.server;
 
 /**
  * An implementation of this interface can manage an underlying stub http server.
- * //TODO closable? Auto-closable?
  */
 public interface StubHttpServerManager {
         
@@ -24,7 +23,7 @@ public interface StubHttpServerManager {
      * @throws JadlerException if an error occurred while stopping the stub http server.
      * @throws IllegalStateException if the stub server hasn't been started yet or has been stopped already.
      */
-    void stop();
+    void close();
     
     
     /**

--- a/jadler-core/src/test/java/net/jadler/stubbing/HttpStubTest.java
+++ b/jadler-core/src/test/java/net/jadler/stubbing/HttpStubTest.java
@@ -21,21 +21,21 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.anything;
 
 
-public class StubRuleTest {
+public class HttpStubTest {
     
     private static final List<StubResponse> DUMB_RESPONSE = Arrays.asList(new StubResponse());
     
 
     @Test(expected=IllegalArgumentException.class)
     public void constructor1() {
-        new StubRule(null, DUMB_RESPONSE);
+        new HttpStub(null, DUMB_RESPONSE);
         fail("predicates cannot be null");
     }
     
     
     @Test(expected=IllegalArgumentException.class)
     public void constructor2() {
-        new StubRule(Collections.<Matcher<? super Request>>emptyList(),
+        new HttpStub(Collections.<Matcher<? super Request>>emptyList(),
                 Collections.<StubResponse>emptyList());
         fail("stubResponses cannot be empty");
     }
@@ -43,22 +43,22 @@ public class StubRuleTest {
     
     @Test
     public void constructor3() {
-        new StubRule(Collections.<Matcher<? super Request>>emptyList(), DUMB_RESPONSE);
+        new HttpStub(Collections.<Matcher<? super Request>>emptyList(), DUMB_RESPONSE);
     }
     
     
     @Test
     @SuppressWarnings("unchecked")
-    public void matchedBy() {
+    public void matches() {
         final Matcher<? super Request> m1 = mock(Matcher.class);
         
         when(m1.matches(any())).thenReturn(false);
         
-        final StubRule rule = new StubRule(
+        final HttpStub rule = new HttpStub(
                 Arrays.<Matcher<? super Request>>asList(anything(), m1, anything()), DUMB_RESPONSE);
         
           //one matcher returns false, this rule is not applicable
-        assertThat(rule.matchedBy(mock(Request.class)), is(false));
+        assertThat(rule.matches(mock(Request.class)), is(false));
     }
     
     
@@ -67,7 +67,7 @@ public class StubRuleTest {
         final StubResponse r1 = new StubResponse();
         final StubResponse r2 = new StubResponse();
         
-        final StubRule rule = new StubRule(Collections.<Matcher<? super Request>>emptyList(),
+        final HttpStub rule = new HttpStub(Collections.<Matcher<? super Request>>emptyList(),
                 Arrays.asList(r1, r2));
         
         assertThat(rule.nextResponse(), is(r1));

--- a/jadler-core/src/test/java/net/jadler/stubbing/StubbingTest.java
+++ b/jadler-core/src/test/java/net/jadler/stubbing/StubbingTest.java
@@ -171,7 +171,7 @@ public class StubbingTest {
     @Test
     public void createRule() {
         this.stubbing.thenRespond();
-        final StubRule rule = this.stubbing.createRule();
+        final HttpStub rule = this.stubbing.createRule();
 
         assertThat(rule, is(notNullValue()));
     }


### PR DESCRIPTION
`JadlerMocker#setDefaultHeaders(final MultiMap defaultHeaders)` removed as well so the MultiMap piece of crap is not exposed on API
