### PR TITLE
Junit rule to instantiate default Jadler instance more easily

### DIFF
--- a/jadler-all/pom.xml
+++ b/jadler-all/pom.xml
@@ -52,6 +52,10 @@ This program is made available under the terms of the MIT License.
             <groupId>net.jadler</groupId>
             <artifactId>jadler-jetty</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.jadler</groupId>
+            <artifactId>jadler-junit</artifactId>
+        </dependency>
         
         <!-- TEST -->
         <dependency> 

--- a/jadler-junit/pom.xml
+++ b/jadler-junit/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jadler-pom</artifactId>
+        <groupId>net.jadler</groupId>
+        <version>1.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jadler-junit</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+
+    <developers>
+        <developer>
+            <name>Christian Galsterer</name>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.jadler</groupId>
+            <artifactId>jadler-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.jadler</groupId>
+            <artifactId>jadler-jetty</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jadler-junit/src/main/java/net/jadler/junit/rule/JadlerRule.java
+++ b/jadler-junit/src/main/java/net/jadler/junit/rule/JadlerRule.java
@@ -1,0 +1,49 @@
+package net.jadler.junit.rule;
+
+import net.jadler.Jadler;
+import net.jadler.stubbing.server.StubHttpServer;
+import org.junit.rules.ExternalResource;
+
+/**
+ * Junit rule which simplifies the creation of a Jadler instance.
+ *
+ * @author Christian Galsterer
+ */
+public class JadlerRule extends ExternalResource {
+
+    public static final int DEFAULT_PORT = -1;
+    private int port = DEFAULT_PORT;
+
+    /**
+     * Initializes Jadler and starts a default stub server {@link net.jadler.stubbing.server.jetty.JettyStubHttpServer}
+     * serving the http protocol listening on any free port.
+     *
+     * See also {@link net.jadler.Jadler#initJadler()}
+     */
+    public JadlerRule() {
+    }
+
+    /**∂
+     * Initializes Jadler and starts a default stub server {@link net.jadler.stubbing.server.jetty.JettyStubHttpServer}
+     * serving the http protocol listening on the given port.
+     *
+     * See also {@link net.jadler.Jadler#initJadlerListeningOn(int)}
+     */
+    public JadlerRule(int port) {
+
+        this.port = port;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        if (port == DEFAULT_PORT)
+            Jadler.initJadler();
+        else
+            Jadler.initJadlerListeningOn(port);
+    }
+
+    @Override
+    protected void after() {
+        Jadler.closeJadler();
+    }
+}

--- a/jadler-junit/src/test/java/net/jadler/junit/rule/JadlerDefaultRuleTest.java
+++ b/jadler-junit/src/test/java/net/jadler/junit/rule/JadlerDefaultRuleTest.java
@@ -1,0 +1,23 @@
+package net.jadler.junit.rule;
+
+import net.jadler.Jadler;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link net.jadler.junit.rule.JadlerRule#JadlerRule()} variant.
+ *
+ * @author Christian Galsterer
+ */
+public class JadlerDefaultRuleTest {
+
+    @Rule
+    public JadlerRule defaultJadler = new JadlerRule();
+
+    @Test
+    public void testWithDefaultPort() {
+         assertTrue(Jadler.port() >= 0);
+    }
+}

--- a/jadler-junit/src/test/java/net/jadler/junit/rule/JadlerFixedPortRuleTest.java
+++ b/jadler-junit/src/test/java/net/jadler/junit/rule/JadlerFixedPortRuleTest.java
@@ -1,0 +1,25 @@
+package net.jadler.junit.rule;
+
+import net.jadler.Jadler;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link net.jadler.junit.rule.JadlerRule#JadlerRule(int)} variant.
+ *
+ * @author Christian Galsterer
+ */
+public class JadlerFixedPortRuleTest {
+
+    private static final int port = 12345;
+
+    @Rule
+    public JadlerRule fixedPortJadler = new JadlerRule(port);
+
+    @Test
+    public void testWithFixedPort() {
+        assertTrue(Jadler.port() == port);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@ This program is made available under the terms of the MIT License.
         <module>jadler-all</module>
         <module>jadler-core</module>
         <module>jadler-jetty</module>
+        <module>jadler-junit</module>
     </modules>
     
 
@@ -59,6 +60,11 @@ This program is made available under the terms of the MIT License.
             <dependency>
                 <groupId>net.jadler</groupId>
                 <artifactId>jadler-jetty</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.jadler</groupId>
+                <artifactId>jadler-junit</artifactId>
                 <version>${project.version}</version>
             </dependency>
             


### PR DESCRIPTION
Jadler is already pretty easy to use. Although not a new feature, Junit rules become more and more popular when setting up a test compared to the traditional setup/teardown pattern as the often require less code. 

This change set is a simple Junit Rule which instantiates Jadler via an @Rule annotation. By this the setup of Jadler becomes even easier as no special setup method is required anymore.

```
    @Rule
    public JadlerRule defaultJadler = new JadlerRule();

```

I found it quite useful and was using it for quite a while with a private extension. Would be nice if you consider this useful as well and integrate into master. If you any questions and need changes before integration just let me know.
