### PR TITLE
 Add mutation tests to Jadler for better unit tests coverage.

### DIFF
--- a/jadler-core/pom.xml
+++ b/jadler-core/pom.xml
@@ -4,8 +4,7 @@ Copyright (c) 2012 - 2016 Jadler contributors
 This program is made available under the terms of the MIT License.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>jadler-core</artifactId>

--- a/jadler-core/pom.xml
+++ b/jadler-core/pom.xml
@@ -4,20 +4,21 @@ Copyright (c) 2012 - 2016 Jadler contributors
 This program is made available under the terms of the MIT License.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>jadler-core</artifactId>
     <name>${project.artifactId}</name>
     <description>Core of the Jadler library.</description>
     <packaging>jar</packaging>
-    
+
     <parent>
         <groupId>net.jadler</groupId>
         <artifactId>jadler-pom</artifactId>
         <version>1.3.1-SNAPSHOT</version>
     </parent>
- 
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -45,11 +46,11 @@ This program is made available under the terms of the MIT License.
         </dependency>
 
         <!-- TEST dependencies -->
-        <dependency> 
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
-        <dependency> 
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
         </dependency>
@@ -62,5 +63,16 @@ This program is made available under the terms of the MIT License.
             <artifactId>mockito-all</artifactId>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <configuration>
+                    <mutationThreshold>70</mutationThreshold>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jadler-jdk/pom.xml
+++ b/jadler-jdk/pom.xml
@@ -46,4 +46,16 @@ This program is made available under the terms of the MIT License.
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <configuration>
+                    <mutationThreshold>70</mutationThreshold>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jadler-jetty/pom.xml
+++ b/jadler-jetty/pom.xml
@@ -64,5 +64,17 @@ This program is made available under the terms of the MIT License.
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <configuration>
+                    <mutationThreshold>20</mutationThreshold>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/jadler-junit/pom.xml
+++ b/jadler-junit/pom.xml
@@ -52,4 +52,17 @@ This program is made available under the terms of the MIT License.
             <artifactId>mockito-all</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <configuration>
+                    <mutationThreshold>70</mutationThreshold>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,28 @@ This program is made available under the terms of the MIT License.
                 </executions>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.pitest</groupId>
+                    <artifactId>pitest-maven</artifactId>
+                    <version>1.1.11</version>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>mutationCoverage</goal>
+                            </goals>
+                            <configuration>
+                                <targetClasses>
+                                    <param>net.jadler*</param>
+                                </targetClasses>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
     
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -246,11 +246,6 @@ This program is made available under the terms of the MIT License.
                             <goals>
                                 <goal>mutationCoverage</goal>
                             </goals>
-                            <configuration>
-                                <targetClasses>
-                                    <param>net.jadler*</param>
-                                </targetClasses>
-                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
Introduces mutation tests (as described on http://pitest.org/).

You can find Pitest coverage report in every submodules' `/target/pit-reports/<time_string>/` directory.