### PR TITLE
Update to Mockito v3.12.4.

### DIFF
--- a/jadler-core/pom.xml
+++ b/jadler-core/pom.xml
@@ -59,7 +59,7 @@ This program is made available under the terms of the MIT License.
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/jadler-core/src/test/java/net/jadler/AbstractRequestMatchingTest.java
+++ b/jadler-core/src/test/java/net/jadler/AbstractRequestMatchingTest.java
@@ -17,7 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
 

--- a/jadler-core/src/test/java/net/jadler/matchers/BodyRequestMatcherTest.java
+++ b/jadler-core/src/test/java/net/jadler/matchers/BodyRequestMatcherTest.java
@@ -9,9 +9,9 @@ import org.junit.Test;
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static net.jadler.matchers.BodyRequestMatcher.requestBody;
 import static org.mockito.Mockito.mock;

--- a/jadler-core/src/test/java/net/jadler/matchers/HeaderRequestMatcherTest.java
+++ b/jadler-core/src/test/java/net/jadler/matchers/HeaderRequestMatcherTest.java
@@ -9,12 +9,12 @@ import org.junit.Test;
 import org.hamcrest.Matcher;
 import java.util.List;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.Mock;
 import net.jadler.KeyValues;
 
-import static org.junit.Assert.assertThat;
 import static net.jadler.matchers.HeaderRequestMatcher.requestHeader;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/jadler-core/src/test/java/net/jadler/matchers/MethodRequestMatcherTest.java
+++ b/jadler-core/src/test/java/net/jadler/matchers/MethodRequestMatcherTest.java
@@ -10,10 +10,10 @@ import org.junit.Test;
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertThat;
 import static net.jadler.matchers.MethodRequestMatcher.requestMethod;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/jadler-core/src/test/java/net/jadler/matchers/ParameterRequestMatcherTest.java
+++ b/jadler-core/src/test/java/net/jadler/matchers/ParameterRequestMatcherTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.hamcrest.Matcher;
 import java.util.List;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.Mock;
 import net.jadler.KeyValues;
 

--- a/jadler-core/src/test/java/net/jadler/matchers/PathRequestMatcherTest.java
+++ b/jadler-core/src/test/java/net/jadler/matchers/PathRequestMatcherTest.java
@@ -10,13 +10,13 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.URI;
 
 import static net.jadler.matchers.PathRequestMatcher.requestPath;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/jadler-core/src/test/java/net/jadler/matchers/QueryStringRequestMatcherTest.java
+++ b/jadler-core/src/test/java/net/jadler/matchers/QueryStringRequestMatcherTest.java
@@ -11,10 +11,10 @@ import org.junit.Test;
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertThat;
 import static net.jadler.matchers.QueryStringRequestMatcher.requestQueryString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/jadler-core/src/test/java/net/jadler/matchers/RawBodyRequestMatcherTest.java
+++ b/jadler-core/src/test/java/net/jadler/matchers/RawBodyRequestMatcherTest.java
@@ -9,11 +9,11 @@ import org.junit.Test;
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.ByteArrayInputStream;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static net.jadler.matchers.RawBodyRequestMatcher.requestRawBody;
 import static org.mockito.Mockito.mock;

--- a/jadler-core/src/test/java/net/jadler/matchers/RequestMatcherTest.java
+++ b/jadler-core/src/test/java/net/jadler/matchers/RequestMatcherTest.java
@@ -13,13 +13,13 @@ import org.hamcrest.StringDescription;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.junit.Before;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
 

--- a/jadler-core/src/test/java/net/jadler/mocking/VerifyingTest.java
+++ b/jadler-core/src/test/java/net/jadler/mocking/VerifyingTest.java
@@ -11,13 +11,13 @@ import net.jadler.RequestManager;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.junit.Before;
 import org.hamcrest.core.IsEqual;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.anyCollection;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.junit.Assert.fail;
@@ -36,7 +36,8 @@ public class VerifyingTest {
     @SuppressWarnings("unchecked")
     public void setUp() {
         doThrow(new VerificationException(""))
-                .when(this.requestManager).evaluateVerification(anyCollection(), any(Matcher.class));
+                .when(this.requestManager)
+                .evaluateVerification(Mockito.<Matcher<? super Request>>anyCollection(), any(Matcher.class));
     }
 
     

--- a/jadler-jdk/pom.xml
+++ b/jadler-jdk/pom.xml
@@ -38,7 +38,7 @@ This program is made available under the terms of the MIT License.
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/jadler-jdk/src/test/java/net/jadler/stubbing/server/jdk/JdkHandlerTest.java
+++ b/jadler-jdk/src/test/java/net/jadler/stubbing/server/jdk/JdkHandlerTest.java
@@ -24,10 +24,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.argThat;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
@@ -146,7 +146,7 @@ public class JdkHandlerTest {
         new JdkHandler(mockManager).handle(httpExchange);
 
         verify(httpExchange).sendResponseHeaders(RESPONSE_STATUS, -1);
-        verifyZeroInteractions(mockResponseStream);
+        verifyNoInteractions(mockResponseStream);
     }
     
     
@@ -155,7 +155,7 @@ public class JdkHandlerTest {
     }
     
     
-    private static class RequestMatcher extends ArgumentMatcher<Request> {
+    private static class RequestMatcher implements ArgumentMatcher<Request> {
 
         private final Request expected;
         
@@ -164,7 +164,7 @@ public class JdkHandlerTest {
         }
         
         @Override
-        public boolean matches(final Object argument) {
+        public boolean matches(final Request argument) {
             final Request arg = (Request) argument;
 
             if (!this.expected.getMethod().equals(arg.getMethod())) {

--- a/jadler-jdk/src/test/java/net/jadler/stubbing/server/jdk/RequestUtilsTest.java
+++ b/jadler-jdk/src/test/java/net/jadler/stubbing/server/jdk/RequestUtilsTest.java
@@ -12,7 +12,7 @@ import net.jadler.Request;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;

--- a/jadler-junit/pom.xml
+++ b/jadler-junit/pom.xml
@@ -53,7 +53,7 @@ This program is made available under the terms of the MIT License.
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,8 @@ This program is made available under the terms of the MIT License.
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.9.5</version>
+                <artifactId>mockito-core</artifactId>
+                <version>3.12.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
* The package moved from `mockito-any` to `mockito-core`
* Use `junit.MockitoJUnitRunner` as `runners.MockitoJUnitRunner` was moved.
* Use `hamcrest` version of `assertThat` because the `junit` version is deprecated.
* Use `verifyNoInteractions` instead of deprecated `verifyZeroInteractions`.
* Explicitly provide type information for `anyCollection`.
* Follow the [`ArgumentMatcher`](https://javadoc.io/static/org.mockito/mockito-core/3.12.4/org/mockito/ArgumentMatcher.html) 2.1.0 migration guide option "a" for `JdkHandlerTest.RequestMatcher`.