### PR TITLE
Use SSH URLs for SCM connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@ This program is made available under the terms of the MIT License.
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/jadler-mocking/jadler.git</connection>
-        <developerConnection>scm:git:https://github.com/jadler-mocking/jadler.git</developerConnection>
+        <connection>scm:git:git@github.com:jadler-mocking/jadler.git</connection>
+        <developerConnection>scm:git:git@github.com:jadler-mocking/jadler.git</developerConnection>
         <url>https://github.com/jadler-mocking/jadler</url>
     </scm>
 


### PR DESCRIPTION
Not to need personal access tokens during releasing